### PR TITLE
use rapidfuzz instead of fuzzywuzzy

### DIFF
--- a/duplicate detection/create_features.py
+++ b/duplicate detection/create_features.py
@@ -1,5 +1,5 @@
 import pandas as pd
-from fuzzywuzzy import fuzz
+from rapidfuzz import fuzz
 from tqdm import tqdm
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ numpy
 wordcloud
 sklearn
 datasketch
-fuzzywuzzy
+rapidfuzz


### PR DESCRIPTION
FuzzyWuzzy is GPLv2 licensed which would force you to licence the whole project under GPLv2.
For this reason this Pullrequest replaces FuzzyWuzzy with  [rapidfuzz](https://github.com/rhasspy/rapidfuzz) which is implementing the same algorithm but is based on a version of fuzzywuzzy that was MIT Licensed.
Rapidfuzz is:
- Mit licensed so it can be used with the license used by this project
- Is faster than FuzzyWuzzy

One thing it does different than fuzzywuzzy is that it returns the results as a float from 1-100% while fuzzywuzzy rounds it to a int. This is done so this precision is not just thrown away by the library, but depending on your requirements you might want to round the results afterwards.